### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/server/api/providers/gemini_provider.ts
+++ b/server/api/providers/gemini_provider.ts
@@ -94,8 +94,16 @@ export async function callGemini(
     }
   };
 
+  // Define an allow-list of valid model names
+  const allowedModels = ['gemini-1.5-pro', 'gemini-2.0', 'gemini-lite'];
+
   // Clean up model name (remove potential 'gemini:' prefix)
   const cleanModelName = modelName.replace('gemini:', '');
+
+  // Validate the cleaned model name against the allow-list
+  if (!allowedModels.includes(cleanModelName)) {
+    throw new Error(`Invalid model name: ${cleanModelName}`);
+  }
 
   // Make API request
   const response = await fetch(


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/1](https://github.com/vetlefo/cogitomap-/security/code-scanning/1)

To fix the SSRF vulnerability, we need to validate and sanitize the `modelName` parameter before using it to construct the URL. The best approach is to use an allow-list of permitted model names. This ensures that only predefined, safe values can be used in the URL, effectively mitigating the risk of SSRF.

**Steps to fix:**
1. Define an allow-list of valid model names in `server/api/providers/gemini_provider.ts`.
2. Validate the `modelName` against the allow-list before constructing the URL.
3. If the `modelName` is not in the allow-list, throw an error or return a response indicating invalid input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
