### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/server/api/semanticAnalysis.ts
+++ b/server/api/semanticAnalysis.ts
@@ -281,7 +281,7 @@ async function performKeywordSearch(
       MATCH (n)
       WHERE n.content IS NOT NULL ${typeFilter}
       WITH n, n.content AS content
-      WHERE ${searchTerms.map(term => `toLower(content) CONTAINS '${term.replace(/'/g, "\\'")}'`).join(' OR ')}
+      WHERE ${searchTerms.map(term => `toLower(content) CONTAINS '${term.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`).join(' OR ')}
       RETURN n.id AS id, n.type AS type, n.content AS content
       LIMIT ${limit}
     `;


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/7](https://github.com/vetlefo/cogitomap-/security/code-scanning/7)

To fix the issue, we need to ensure that both single quotes and backslashes in the `term` variable are properly escaped. This can be achieved by replacing backslashes first (to avoid double-escaping issues) and then replacing single quotes. Alternatively, we can use a well-tested library for escaping strings in Cypher queries, but since no such library is explicitly mentioned in the code, we will implement the fix manually.

The changes will be made to line 284, where the `term.replace` logic is located. The updated code will use a chained `replace` method to handle both backslashes and single quotes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
