### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/scripts/db-diagnostics/testConnection.js
+++ b/scripts/db-diagnostics/testConnection.js
@@ -7,7 +7,7 @@ const MEMGRAPH_USERNAME = process.env.MEMGRAPH_USERNAME;
 const MEMGRAPH_PASSWORD = process.env.MEMGRAPH_PASSWORD;
 
 console.log(`Attempting to connect to Memgraph at ${MEMGRAPH_URI}`);
-console.log(`Using username: ${MEMGRAPH_USERNAME}`);
+console.log(`Using username: ${MEMGRAPH_USERNAME ? "provided" : "not provided"}`);
 console.log(`Password length: ${MEMGRAPH_PASSWORD ? MEMGRAPH_PASSWORD.length : 0}`);
 
 const testMemgraphConnection = async (uri, username, password) => {


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/5](https://github.com/vetlefo/cogitomap-/security/code-scanning/5)

To fix the issue, we should avoid logging sensitive information such as the username in clear text. Instead, we can log a generic message or obfuscate the sensitive data. For example, we can log the presence of a username without revealing its value. This ensures that the logs remain informative for debugging purposes without exposing sensitive information.

Specifically:
1. Replace the log statement on line 10 with a message that does not include the username value. For instance, we can log whether a username is provided or not.
2. Ensure that no sensitive information is logged elsewhere in the script.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
