### PR TITLE
Potential fix for code scanning alert no. 4: Loop bound injection

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -553,7 +553,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // New route for SSR-friendly semantic results
   app.get('/api/graph/semantic-ssr', async (req: Request, res: Response) => {
     try {
-      const queryText = req.query.query as string;
+      const queryText = (req.query.query as string)?.slice(0, 1000); // Truncate to MAX_TEXT_LENGTH
       const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 5;
       const minSimilarity = req.query.minSimilarity ? parseFloat(req.query.minSimilarity as string) : 0.7;
       const nodeTypesQuery = req.query.nodeTypes as string;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -553,7 +553,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // New route for SSR-friendly semantic results
   app.get('/api/graph/semantic-ssr', async (req: Request, res: Response) => {
     try {
-      const queryText = (req.query.query as string)?.slice(0, 1000); // Truncate to MAX_TEXT_LENGTH
+      const queryParam = req.query.query;
+      if (typeof queryParam !== 'string') {
+        return res.status(400).json({ error: "Query parameter 'query' must be a string." });
+      }
+      const queryText = queryParam.slice(0, 1000); // Truncate to MAX_TEXT_LENGTH
       const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 5;
       const minSimilarity = req.query.minSimilarity ? parseFloat(req.query.minSimilarity as string) : 0.7;
       const nodeTypesQuery = req.query.nodeTypes as string;

--- a/server/services/embeddingService.ts
+++ b/server/services/embeddingService.ts
@@ -535,7 +535,12 @@ function generateFallbackEmbedding(text: string, dimensions: number = DEFAULT_DI
   const embedding = new Array(dimensions).fill(0);
   
   // Normalize text
-  const normalizedText = text.toLowerCase().trim().slice(0, MAX_TEXT_LENGTH);
+  let normalizedText = text.toLowerCase().trim().slice(0, MAX_TEXT_LENGTH);
+  
+  // Ensure normalizedText length does not exceed MAX_TEXT_LENGTH
+  if (normalizedText.length > MAX_TEXT_LENGTH) {
+    normalizedText = normalizedText.slice(0, MAX_TEXT_LENGTH);
+  }
   
   // Generate a deterministic hash-based embedding
   for (let i = 0; i < normalizedText.length; i++) {

--- a/server/services/embeddingService.ts
+++ b/server/services/embeddingService.ts
@@ -17,6 +17,9 @@ const STORAGE_DIMENSIONS = 384; // Further reduced for efficient storage
 // Reduced dimensions for 3D visualization
 const VISUALIZATION_DIMENSIONS = 3;
 
+// Maximum length for input text to prevent excessive processing
+const MAX_TEXT_LENGTH = 1000; // Adjust as needed based on application requirements
+
 /**
  * Generate an embedding vector for text content using OpenAI's embedding API
  * @param text The text to generate an embedding for
@@ -532,7 +535,7 @@ function generateFallbackEmbedding(text: string, dimensions: number = DEFAULT_DI
   const embedding = new Array(dimensions).fill(0);
   
   // Normalize text
-  const normalizedText = text.toLowerCase().trim();
+  const normalizedText = text.toLowerCase().trim().slice(0, MAX_TEXT_LENGTH);
   
   // Generate a deterministic hash-based embedding
   for (let i = 0; i < normalizedText.length; i++) {


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/4](https://github.com/vetlefo/cogitomap-/security/code-scanning/4)

To fix the issue, we need to ensure that the length of the `text` parameter passed to `generateFallbackEmbedding` is bounded. This can be achieved by truncating the input string to a reasonable maximum length before processing it. Additionally, we should validate the input in `server/routes.ts` to enforce this constraint at the earliest point in the data flow.

1. Add a maximum length constant (e.g., `MAX_TEXT_LENGTH`) to `server/services/embeddingService.ts`.
2. Truncate the `text` parameter to this maximum length in the `generateFallbackEmbedding` function.
3. Validate and truncate `req.query.query` in `server/routes.ts` to ensure that excessively large input is rejected or truncated before reaching the embedding service.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
