### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "ws": "^8.18.0",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.4.1",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -81,8 +82,14 @@ export function serveStatic(app: Express) {
 
   app.use(express.static(distPath));
 
+  // Define rate limiter: maximum of 100 requests per 15 minutes
+  const staticFileRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
   // fall through to index.html if the file doesn't exist
-  app.use("*", (_req, res) => {
+  app.use("*", staticFileRateLimiter, (_req, res) => {
     res.sendFile(path.resolve(distPath, "index.html"));
   });
 }


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/3](https://github.com/vetlefo/cogitomap-/security/code-scanning/3)

To address the issue, we will introduce rate limiting to the route handler in the `serveStatic` function. We will use the `express-rate-limit` package, a well-known middleware for rate limiting in Express applications. This middleware will restrict the number of requests a client can make to the endpoint within a specified time window.

Steps to fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `rateLimit` function from the package.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the route handler in the `serveStatic` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
