### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "ws": "^8.18.0",
     "zod": "^3.23.8",
     "zod-validation-error": "^3.4.1",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@replit/vite-plugin-runtime-error-modal": "^0.0.3",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path, { dirname } from "path";
 import { fileURLToPath } from "url";
@@ -44,6 +45,15 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
+
+  // Define rate limiter: max 100 requests per 15 minutes
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  app.use(limiter);
+
   app.use("*", async (req, res, next) => {
     const url = req.originalUrl;
 


### PR DESCRIPTION
Potential fix for [https://github.com/vetlefo/cogitomap-/security/code-scanning/2](https://github.com/vetlefo/cogitomap-/security/code-scanning/2)

To address the issue, we will introduce rate limiting to the route handler using the `express-rate-limit` package. This package allows us to define a maximum number of requests that can be made to the route within a specified time window. Specifically:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `rateLimit` function from the package.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the route handler on line 47.

This fix ensures that the route is protected from excessive requests, mitigating the risk of a DoS attack.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
